### PR TITLE
use the expected target rather than event.target

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ Mouse.prototype = {
 
 	computeCustomOffset: function(event) {
 		if(this.offsetRelativeToTarget) {
-			var clientRect = getClientRect(event.target);
+			var clientRect = getClientRect(this.targetElement);
 			event.offsetX2 = event.clientX - clientRect.left;
 			event.offsetY2 = event.clientY - clientRect.top;
 		} else {


### PR DESCRIPTION
always compute the bounds of the expected target, rather than whatever happens to be the target under the mouse (`event.target`) 
